### PR TITLE
Update funcs.py

### DIFF
--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -186,7 +186,7 @@ def rectangular_prism(width, height, axis='z', origin=(0., 0.),
             raise ValueError('Periodic boundary conditions not permitted when '
                              'rounded corners are used.')
 
-        args = {'R': corner_radius, 'boundary_type': boundary_type}
+        args = {'r': corner_radius, 'boundary_type': boundary_type}
 
         args[x1 + '0'] = origin[0] - width/2 + corner_radius
         args[x2 + '0'] = origin[1] - height/2 + corner_radius


### PR DESCRIPTION
This modification will eliminate the warning:
/home/valerio/.local/lib/python3.8/site-packages/openmc/surface.py:1510: FutureWarning: "ZCylinder(…) accepts an argument named ‘r’, not ‘R’. Future versions of OpenMC will not accept the capitalized version.
warn(_WARNING_UPPER.format(type(self).name, ‘r’, ‘R’)