### PR TITLE
Update universe.py

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -361,7 +361,7 @@ class Universe(UniverseBase):
             img_path = Path(tmpdir) / f'plot_{plot.id}.png'
             if not img_path.is_file():
                 img_path = img_path.with_suffix('.ppm')
-            img = mpimg.imread(img_path)
+            img = mpimg.imread(str(img_path))
 
             # Create a figure sized such that the size of the axes within
             # exactly matches the number of pixels specified


### PR DESCRIPTION
Running a Jupyter notebook prepared some time ago, I got the following error when trying to plot a universe.

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-6d5315041afe> in <module>
      1 universe = openmc.Universe(cells=(fuel, moderator))
----> 2 universe.plot(origin=[0.,0.,0.],width=[2.4,2.4],basis='xy')

~/.local/lib/python3.8/site-packages/openmc/universe.py in plot(self, origin, width, pixels, basis, color_by, colors, seed, openmc_exec, axes, **kwargs)
    362             if not img_path.is_file():
    363                 img_path = img_path.with_suffix('.ppm')
--> 364             img = mpimg.imread(img_path)
    365 
    366             # Create a figure sized such that the size of the axes within

/usr/lib/python3/dist-packages/matplotlib/image.py in imread(fname, format)
   1434                 return handler(fd)
   1435     else:
-> 1436         return handler(fname)
   1437 
   1438 

/usr/lib/python3/dist-packages/matplotlib/image.py in read_png(*args, **kwargs)
   1388     def read_png(*args, **kwargs):
   1389         from matplotlib import _png
-> 1390         return _png.read_png(*args, **kwargs)
   1391 
   1392     handlers = {'png': read_png, }

TypeError: Object does not appear to be a 8-bit string path or a Python file-like object

```
The error disappears and the plot is correctly shown if line 364 is changed as follows:

`img = mpimg.imread(str(img_path))`

Does this change sound reasonable?